### PR TITLE
feat: Add keyboard shortcuts for audio control

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,6 +13,54 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 
+  //Keyboard Shortcuts buttons
+  document.addEventListener("keydown", function (e) {
+    switch (e.code) {
+      case "Space": // Play / Pause
+        e.preventDefault(); // Prevents page scrolling when Space is pressed
+        if (audioPlayer.paused) {
+          audioPlayer.play();
+        } else {
+          audioPlayer.pause();
+        }
+        break;
+
+      case "ArrowRight": // Jump forward 30 seconds
+        audioPlayer.currentTime += 30;
+        break;
+
+      case "ArrowLeft": // Go back 30 seconds
+        audioPlayer.currentTime -= 30;
+        break;
+
+      case "Equal": // Increase volume
+        if (audioPlayer.volume < 1) {
+          audioPlayer.volume = Math.min(audioPlayer.volume + 0.1, 1);
+        }
+        break;
+
+      case "NumpadAdd": // Augmenter le volume avec le pavé numérique
+        if (audioPlayer.volume < 1) {
+          audioPlayer.volume = Math.min(audioPlayer.volume + 0.1, 1);
+        }
+        break;
+
+      case "Minus": // Reduce volume
+        if (audioPlayer.volume > 0) {
+          audioPlayer.volume = Math.max(audioPlayer.volume - 0.1, 0);
+        }
+        break;
+      case "NumpadSubtract": // Diminuer le volume avec le pavé numérique
+        if (audioPlayer.volume > 0) {
+          audioPlayer.volume = Math.max(audioPlayer.volume - 0.1, 0);
+        }
+        break;
+
+      default:
+        break;
+    }
+  });
+
   // Comment Submission
   document
     .getElementById("comment-form")

--- a/style.css
+++ b/style.css
@@ -62,12 +62,17 @@ footer a:hover {
 
 .bi {
   cursor: pointer;
+  transition: transform 0.6s ease-in-out 0.3s;
+  will-change: transform;
 }
 
+.bi:hover {
+  transform: scale(1.2);
+}
 body.dark-theme .playlist-card {
   width: 100%;
   background-color: #181818;
-  transition: transform 0.3s, box-shadow 0.3s;
+  transition: transform 0s, box-shadow 0.3s;
 }
 body.light-theme .playlist-card {
   background-color: #ffffff;

--- a/style.css
+++ b/style.css
@@ -72,7 +72,7 @@ footer a:hover {
 body.dark-theme .playlist-card {
   width: 100%;
   background-color: #181818;
-  transition: transform 0s, box-shadow 0.3s;
+  transition: transform 0.3s, box-shadow 0.3s;
 }
 body.light-theme .playlist-card {
   background-color: #ffffff;


### PR DESCRIPTION
- Implemented keyboard shortcuts for audio playback:
  - Spacebar for play/pause
  - Arrow keys for skipping 30 seconds forward/backward
  - '+' (plus) and '-' (minus) keys for volume control
  - Added support for numeric keypad '+' and '-' keys for volume adjustment
- Updated shortcut list displayed on the audio player page to reflect new controls