### PR TITLE
[Enhance] Update audio slider to dynamically show progress

### DIFF
--- a/script.js
+++ b/script.js
@@ -319,14 +319,51 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     });
 
+    // Update the slider background based on the current time
+    function updateSliderBackground() {
+      if (audioPlayer.duration > 0) {
+        let playedPercentage = (audioPlayer.currentTime / audioPlayer.duration) * 100;
+        playedPercentage = Math.min(playedPercentage, 100);
+    
+        // Dynamically update the slider track background for WebKit and Mozilla
+        const sliderStyle = document.querySelector('style#sliderStyle');
+        if (sliderStyle) {
+          sliderStyle.innerHTML = `
+            input[type="range"]#seekSlider::-webkit-slider-runnable-track {
+              background: linear-gradient(to right, var(--accent-background-color) ${playedPercentage}%, gray ${playedPercentage}%);
+            }
+            input[type="range"]#seekSlider::-moz-range-track {
+              background: linear-gradient(to right, var(--accent-background-color) ${playedPercentage}%, gray ${playedPercentage}%);
+            }
+          `;
+        } else {
+          const styleTag = document.createElement('style');
+          styleTag.id = 'sliderStyle';
+          styleTag.innerHTML = `
+            input[type="range"]#seekSlider::-webkit-slider-runnable-track {
+              background: linear-gradient(to right, var(--accent-background-color) ${playedPercentage}%, gray ${playedPercentage}%);
+            }
+            input[type="range"]#seekSlider::-moz-range-track {
+              background: linear-gradient(to right, var(--accent-background-color) ${playedPercentage}%, gray ${playedPercentage}%);
+            }
+          `;
+          document.head.appendChild(styleTag);
+        }
+      }
+    }
+    
+    
+
     // Seek Player
     audioPlayer.addEventListener("timeupdate", () => {
       seekSlider.value = audioPlayer.currentTime;
       currentTimeLabel.textContent = formatTime(audioPlayer.currentTime);
+      updateSliderBackground();
     });
     // Seek functionality
     seekSlider.addEventListener("input", (event) => {
       audioPlayer.currentTime = event.target.value;
+      updateSliderBackground();
     });
 
     // Format time from seconds to MM:SS
@@ -344,6 +381,7 @@ document.addEventListener("DOMContentLoaded", function () {
     audioPlayer.addEventListener("loadedmetadata", () => {
       durationLabel.textContent = formatTime(audioPlayer.duration);
       seekSlider.max = audioPlayer.duration;
+      updateSliderBackground();
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -476,24 +476,35 @@ input[type="range"]#seekSlider {
 input[type="range"]#seekSlider::-webkit-slider-runnable-track {
   width: 100%;
   height: 5px;
-  background: var(--accent-background-color);
+  background: linear-gradient(to right, var(--accent-background-color) 0%, gray 0%);
   border-radius: 5px;
 }
 
 input[type="range"]#seekSlider::-moz-range-track {
   width: 100%;
   height: 5px;
-  background: var(--accent-background-color);
+  background: linear-gradient(to right, var(--accent-background-color) 0%, gray 0%);
   border-radius: 5px;
 }
 
 input[type="range"]#seekSlider::-ms-track {
   width: 100%;
   height: 5px;
-  background: var(--accent-background-color);
+  background: transparent;
   border-radius: 5px;
   border-color: transparent;
   color: transparent;
+}
+
+/* Hide the default slider appearance for IE */
+input[type="range"]#seekSlider::-ms-fill-lower {
+  background: var(--accent-background-color);
+  border-radius: 5px;
+}
+
+input[type="range"]#seekSlider::-ms-fill-upper {
+  background: gray;
+  border-radius: 5px;
 }
 
 /* Slider thumb (the draggable part) */


### PR DESCRIPTION
# Description
- Fix the audio player slider bar to update to show the listen percentage dynamically.
- Fixes: #121 

# How to recreate
- Go to the audio player section using the buttons.
- Play the audio and move the slider around.
- Observe as it is updating dynamically.

# Solution
-  Add update slider to dynamically track the listened percentage and show the progress in the slider.

# Screenshot

Before:
![Screenshot 2024-10-21 233153](https://github.com/user-attachments/assets/73491461-1264-45c6-96c7-7c9e25d305f0)

After:
![Screenshot 2024-10-22 000245](https://github.com/user-attachments/assets/bf75a612-a14b-4c65-b127-bf1f76c6e400)
