### PR TITLE
fix: explore books button redirect fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
         <span id="typed-text"></span>
       </div>
       <div class="animate-fade-in-up-delayed-2">
-        <a href="./explore-books.html" class="inline-block bg-green-500 hover:bg-green-600 text-white font-semibold py-3 px-8 rounded-full transition duration-300 ease-in-out transform hover:scale-105 hover:shadow-lg focus:outline-none focus:ring-4 focus:ring-green-300 animate-bounce-subtle">
+        <a href="./explore.html" class="inline-block bg-green-500 hover:bg-green-600 text-white font-semibold py-3 px-8 rounded-full transition duration-300 ease-in-out transform hover:scale-105 hover:shadow-lg focus:outline-none focus:ring-4 focus:ring-green-300 animate-bounce-subtle">
           Explore Books
         </a>
         <p class="text-sm text-gray-400 mt-4 animate-fade-in">Discover amazing stories and knowledge</p>


### PR DESCRIPTION
This pull request makes a small change to the navigation link on the homepage. The "Explore Books" button now directs users to `explore.html` instead of `explore-books.html`.

Fixed #202 