### PR TITLE
Fix: Use relative path for chatbot data fetching

### DIFF
--- a/script.js
+++ b/script.js
@@ -1005,7 +1005,7 @@ document.addEventListener("DOMContentLoaded", function () {
       console.log("ChatbotButton Clicked");
       if (!booksData) {
         try {
-          const res = await fetch("https://raw.githubusercontent.com/Ctoic/Lisbook/refs/heads/main/data/books.json");
+          const res = await fetch("data/books.json");
           booksData = await res.json();
         } catch (e) {
           booksData = null;

--- a/tests/test_chatbot_fetch.py
+++ b/tests/test_chatbot_fetch.py
@@ -1,0 +1,34 @@
+from playwright.sync_api import sync_playwright
+
+def test_chatbot_data_fetch_with_relative_path():
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+
+        # Arrays to store requests
+        successful_requests = []
+        failed_requests = []
+        page.on("requestfinished", lambda request: successful_requests.append(request.url))
+        page.on("requestfailed", lambda request: failed_requests.append(request.url))
+
+        # Load the page from the local server
+        page.goto("http://localhost:8000/index.html")
+
+        # Click the chatbot button and wait for the window to appear
+        page.click("#chatbot-button")
+        page.wait_for_selector("#chatbot-window")
+
+        # Give the fetch a moment to complete
+        page.wait_for_timeout(1000)
+
+        # Assert that the request to books.json was successful and not failed
+        assert any("data/books.json" in url for url in successful_requests), \
+            "The request to data/books.json was not successful."
+        assert not any("data/books.json" in url for url in failed_requests), \
+            "The request to data/books.json failed."
+
+        print("Test passed: Chatbot fetched book data successfully from the local server.")
+        browser.close()
+
+if __name__ == "__main__":
+    test_chatbot_data_fetch_with_relative_path()


### PR DESCRIPTION
The chatbot was previously fetching book data from a hardcoded GitHub URL, which made it dependent on a specific branch and non-functional in other environments.

This change updates the `fetch` call in `script.js` to use a relative path (`data/books.json`), making the feature branch-independent.

A Playwright test has been added to verify that the chatbot can successfully fetch data from a local web server, ensuring the fix is working as intended.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/cfd8e1f2-11b2-4679-9ebb-3bbd091a5a8b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application to load book data from a local source instead of remote.

* **Tests**
  * Added end-to-end test validating local data loading functionality for the chatbot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->