### PR TITLE
fix: dark/light theme bug fix

### DIFF
--- a/explore_style.css
+++ b/explore_style.css
@@ -350,8 +350,15 @@ body {
 
 /* Search and Filter Styles */
 .search-filter-section {
-    /* Remove background to match web app design */
-    padding: 2rem 0;
+    padding: 1rem 1.5rem; /* Consistent padding */
+    background-color: #ffffff; /* Light mode background */
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05); 
+    
+    /* Core Layout */
+    display: flex;         
+    align-items: center;   
+    gap: 1.5rem;           
+    flex-wrap: wrap; /* Allow wrapping ONLY on very small screens */
 }
 
 /* Side-by-side search and filter layout */
@@ -361,11 +368,15 @@ body {
     gap: 2rem;
     background: transparent; /* Match body background */
     padding: 0;
+    width: 100%;
+    max-width: none;
+    margin-left: 0;
+    margin-right: 0;
 }
 
 .search-container {
-    flex: 1;
-    min-width: 0; /* Allow flex item to shrink */
+    flex: 1 1 auto; /* Allow grow and shrink, basis auto */
+    min-width: 250px;
 }
 
 .search-wrapper {
@@ -377,13 +388,12 @@ body {
 }
 
 .filter-container {
-    flex: 1;
-    min-width: 0; /* Allow flex item to shrink */
+    flex-shrink: 0;
 }
 
 .filter-wrapper {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 1rem;
     align-items: flex-end;
     justify-content: flex-end;
@@ -758,4 +768,39 @@ body.light-theme .search-filter-section .search-icon-container i {
     .recommendation-card p {
         font-size: 0.8rem;
     }
+}
+/* ADD THIS BLOCK AT THE BOTTOM OF YOUR CSS FILE */
+
+/* Force the inner containers within the search section to be full width */
+.search-filter-section .container,
+.search-filter-section .search-filter-wrapper {
+  max-width: none; /* Override any max-width utilities (like max-w-7xl) */
+  margin-left: 0;  /* Override centering (like mx-auto) */
+  margin-right: 0; /* Override centering (like mx-auto) */
+  width: 100%;     /* Ensure it takes full available width */
+}
+
+/* Optional: Remove extra padding added by the .container utility if needed */
+.search-filter-section .container {
+    padding-left: 0;
+    padding-right: 0;
+}
+
+/* Ensure the main section itself still has some padding */
+.search-filter-section {
+    /* Keep existing styles like background, border, display:flex etc. */
+    background-color: #ffffff;
+    padding: 1rem; /* Adjust overall padding if needed */
+    display: flex;         
+    align-items: center;   
+    gap: 1.5rem;           
+    flex-wrap: wrap; 
+    width: 100%; /* Ensure the section itself is full width */
+}
+
+.dark-theme .search-filter-section {
+}
+.dark-theme .search-filter-section .container,
+.dark-theme .search-filter-section .search-filter-wrapper {
+    /* No special dark mode layout needed if base styles are correct */
 }


### PR DESCRIPTION
Hi there,

This PR fixes a visual inconsistency in the search and filter section on the Explore page, as discussed in issue #282 

Description:
Currently, the container holding the search bar and filter dropdowns behaves differently between light and dark modes:
- Dark Mode: The container correctly spans the full width of the main content area.
- Light Mode: The container was incorrectly applying centering and max-width styles (likely from utility classes like `.container` causing it to appear narrower and centered.

This PR addresses the issue by adding CSS rules specifically targeting the inner containers (`.container`, `.search-filter-wrapper`) within the `.search-filter-section`. These rules override the conflicting utility classes in light mode by setting `max-width: none;`, `margin-left: 0;`, `margin-right: 0;`, and `width: 100%;`.

| Before | After |
| :-----------------------------: | :----------------------------: |
| ![Before Screenshot](https://github.com/user-attachments/assets/71d06977-2f87-4e37-a91a-54d0898de7f7) | ![After Screenshot](https://github.com/user-attachments/assets/977b4c48-9afb-4e4e-80d6-f00359ee6bc3) |

Testing
I have verified locally that this change corrects the layout issue in light mode, making it consistent with the correct dark mode layout.

Thanks, Let me know if there are any feedbacks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced Search and Filter section styling with improved spacing, background styling, and visual refinements.
  * Optimized responsive layout behavior for improved mobile experience.
  * Improved visual consistency across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->